### PR TITLE
Remove Makerthon Melbourne

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ To add a hackathon to this list, please submit an issue or fork this repo and su
 | 1 Mar     | [Red Cross Hackathon](https://www.eventbrite.com.au/e/red-cross-hackathon-advancing-social-cohesion-tickets-20937217782?aff=es2)   |  Swanston Street, Carlton. FREE   |
 | 4 - 6 Mar | [Science Hackfest](http://sciencehackau.github.io/melbourne/)   |  LAB-14, Carlton Connect. Uni Melb. FREE |
 | 18 - 20 Mar  | [CodeBrew](http://codebrew.net.au/)   |  Run by UniMelb CISSA. York Butter Factory. $30.  |
-| 19 - 20 Mar  | [Makerthon Melbourne](http://www.makerthonmelbourne.com/)   |  Hardware and gadgets. TBC. Going ahead??? |
 | 23 Mar  | [Hackathon@Outware](http://www.codeforaustralia.org/events/hackathon-outware-mobile)   |  Quick 3hr Hack, La Trobe Street. |
 | Mid Apr  | [Telstra Hackathon](https://hackathongoddess.wordpress.com/tag/telstra/)   |  TBC. |
 | 15-17 Apr  | [Techfugees](http://techfugees.com/)   |  Refugee crisis solutions. Launchpad, Richmond. |


### PR DESCRIPTION
Couldn't get things ready in time to make it the event I want it to be. Will be having another crack 2017
